### PR TITLE
Fix "tail: cannot open" logging error

### DIFF
--- a/root/etc/services.d/teamspeak/run
+++ b/root/etc/services.d/teamspeak/run
@@ -8,4 +8,4 @@ done
 
 exec \
 	s6-setuidgid abc tail -F -q --pid="$(cat /config/serverfiles/ts3server.pid)" \
-	"$(find /config/serverfiles/logs -printf '%C@ %p\n' |sort | head -n 2)"
+	/dev/null


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]
	

<!--- Before submitting a pull request please check the following -->

<!---  That you have made a branch in your fork, we'd rather not merge from your master -->
<!---  That if the PR is addressing an existing issue include, closes #<issue number> , in the body of the PR commit message   -->
<!---  You have included links to any files / patches etc your PR may be using in the body of the PR commit message -->
<!---  -->

##  Thanks, team linuxserver.io

Per the conversations over in #16 due to the fact that TS3 cannot foreground, we are currently tricking s6 by running a tail -f on some files.
This results in an error in the logs from launch, which can be observed by running: `docker logs -f containername`
Here's an example snippet:
```
[cont-init.d] 10-adduser: exited 0.
[cont-init.d] 30-install: executing...
[cont-init.d] 30-install: exited 0.
[cont-init.d] done.
[services.d] starting services
[services.d] done.
[  OK  ] Starting ts3-server: TeamSpeak 3 Server
tail: cannot open '1520128030.3469958540 /config/serverfiles/logs/ts3server_2018-02-23__04_00_56.569798_1.log'$'\n''1520128030.3469958540 /config/serverfiles/logs/ts3server_2018-02-24__10_13_47.363892_0.log' for reading: No such file or directory
```

Since the purpose isn't to display any actual logging due to rollover, this change just tails /dev/null which will remove the error and continue to trick s6 to think that the service is running in the foreground.