### PR TITLE
Fix download location for ts3server script

### DIFF
--- a/root/etc/cont-init.d/30-install
+++ b/root/etc/cont-init.d/30-install
@@ -5,7 +5,7 @@ mkdir -p /config/serverfiles
 
 # fetch installer
 if [ ! -e /config/ts3server ]; then
-wget -O /config/ts3server http://gameservermanagers.com/dl/ts3server
+wget -O /config/ts3server http://linuxgsm.com/dl/ts3server
 chmod +x /config/ts3server
 fi
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]
	

<!--- Before submitting a pull request please check the following -->

<!---  That you have made a branch in your fork, we'd rather not merge from your master -->
<!---  That if the PR is addressing an existing issue include, closes #<issue number> , in the body of the PR commit message   -->
<!---  You have included links to any files / patches etc your PR may be using in the body of the PR commit message -->
<!---  -->

##  Thanks, team linuxserver.io

The current location for the ts3server script downloaded as part of an initial server install is no longer being served out of the gameservermanagers.com domain.

This change replaces the old domain with the current domain, alternatively this can be replaced with the github location, said new domain appears to be forwarding to: `https://raw.githubusercontent.com/GameServerManagers/LinuxGSM/legacy/TeamSpeak3/ts3server`

Please let me know if you would like me to modify to said location.