### PR TITLE
Added missing dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,7 @@ ENV TS3SERVER_LICENSE="accept"
 
 RUN \
  echo "**** install packages ****" && \
+ dpkg --add-architecture i386 && \
  apt-get update && \
  apt-get install -y \
 	bc \
@@ -27,6 +28,8 @@ RUN \
 	tmux \
 	unzip \
 	util-linux \
+	lib32gcc1 \
+	libstdc++6:i386 \
 	wget && \
  echo "**** cleanup ****" && \
  apt-get clean && \


### PR DESCRIPTION
Adds i386 architecture and dependencies required by the current GSM install script.
Together with #20 the image works again.

