### PR TITLE
fix installer without using bogus 386 dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,13 +18,12 @@ RUN \
 	binutils \
 	bsdmainutils \
 	bzip2 \
+	ca-certificates \
 	curl \
 	file \
-	libmariadb2 \
-	mailutils \
-	postfix \
+	gzip \
+	jq \
 	python \
-	tmux \
 	unzip \
 	util-linux \
 	wget && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,6 +23,9 @@ RUN \
 	file \
 	gzip \
 	jq \
+	libmariadb2 \
+	mailutils \
+	postfix \
 	python \
 	unzip \
 	util-linux \

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ There is no setup required, just start the container, watch the log and note the
 
 ## Versions
 
-+ **23.07.18:** Fix installer link and update dependencies.
++ **23.07.18:** Fix installer link.
 + **04.03.18:** Tail log to /dev/null to clear up file cannot be found.
 + **19.02.18:** Add license accept variable and print warning in init to view license.
 + **12.12.17:** Fix continuation lines.

--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ There is no setup required, just start the container, watch the log and note the
 
 ## Versions
 
++ **23.07.18:** Fix installer link and update dependencies.
 + **04.03.18:** Tail log to /dev/null to clear up file cannot be found.
 + **19.02.18:** Add license accept variable and print warning in init to view license.
 + **12.12.17:** Fix continuation lines.

--- a/root/etc/cont-init.d/30-install
+++ b/root/etc/cont-init.d/30-install
@@ -6,7 +6,7 @@ mkdir -p /config/serverfiles
 # fetch installer
 if [ ! -e /config/ts3server ]; then
 wget -O /tmp/linuxgsm.sh https://Linuxgsm.sh
-cd /tmp
+cd /tmp || exit
 s6-setuidgid abc /bin/bash /tmp/linuxgsm.sh ts3server
 mv /tmp/ts3server /config/ts3server
 rm -rf /tmp/l*

--- a/root/etc/cont-init.d/30-install
+++ b/root/etc/cont-init.d/30-install
@@ -5,7 +5,11 @@ mkdir -p /config/serverfiles
 
 # fetch installer
 if [ ! -e /config/ts3server ]; then
-wget -O /config/ts3server http://gameservermanagers.com/dl/ts3server
+wget -O /tmp/linuxgsm.sh https://Linuxgsm.sh
+cd /tmp
+s6-setuidgid abc /bin/bash /tmp/linuxgsm.sh ts3server
+mv /tmp/ts3server /config/ts3server
+rm -rf /tmp/l*
 chmod +x /config/ts3server
 fi
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]
	

<!--- Before submitting a pull request please check the following -->

<!---  That you have made a branch in your fork, we'd rather not merge from your master -->
<!---  That if the PR is addressing an existing issue include, closes #<issue number> , in the body of the PR commit message   -->
<!---  You have included links to any files / patches etc your PR may be using in the body of the PR commit message -->
<!---  -->

##  Thanks, team linuxserver.io

